### PR TITLE
RSpec: Add Test of scope :postable

### DIFF
--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe '.postable' do
+      it 'returns only postable and active articles' do
+        postable_article = create(:article, user:, is_postable: true, is_active: true)
+        not_postable_article = create(:article, user:, is_postable: false, is_active: true)
+        inactive_article = create(:article, user:, is_postable: true, is_active: false)
+
+        postable_articles = Article.postable
+
+        expect(postable_articles).to include(postable_article)
+        expect(postable_articles).not_to include(not_postable_article)
+        expect(postable_articles).not_to include(inactive_article)
+      end
+    end
+  end
+
   describe '.random_postable_article' do
     it 'returns a postable article' do
       create(:article, user:, is_postable: true, is_active: true)


### PR DESCRIPTION
- mattermostではなくconsoleでzenn_usernameを空に更新していたため、紐づく記事が`is_active: false`に更新されていなかった
  - consoleで紐づく記事が`is_active: false`に更新済み

-  RSpecで、直接`scope :postable`のテストを追加
    - 元々あった`random_postable_article`のテストと役割類似している