### PR TITLE
Comment out/schedule national holiday jobs

### DIFF
--- a/app/jobs/fetch_articles_job.rb
+++ b/app/jobs/fetch_articles_job.rb
@@ -1,6 +1,6 @@
 class FetchArticlesJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: 1, backtrace: true, unique: :until_and_while_executing
+  sidekiq_options retry: 3, backtrace: true, unique: :until_and_while_executing
 
   def perform(qiita_username = nil, zenn_username = nil)
     if qiita_username || zenn_username

--- a/app/jobs/post_to_x_job.rb
+++ b/app/jobs/post_to_x_job.rb
@@ -1,6 +1,6 @@
 class PostToXJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: 1, backtrace: true, unique: :until_and_while_executing
+  sidekiq_options retry: 3, backtrace: true, unique: :until_and_while_executing
 
   def perform
     execute_posting_logic

--- a/app/jobs/record_post_in_sheets_job.rb
+++ b/app/jobs/record_post_in_sheets_job.rb
@@ -1,6 +1,6 @@
 class RecordPostInSheetsJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: 1, backtrace: true, unique: :until_and_while_executing
+  sidekiq_options retry: 3, backtrace: true, unique: :until_and_while_executing
 
   def perform(params)
     article = Article.find_by(id: params[:article_id])

--- a/app/jobs/send_gmail_job.rb
+++ b/app/jobs/send_gmail_job.rb
@@ -1,6 +1,6 @@
 class SendGmailJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: 1, backtrace: true, unique: :until_and_while_executing
+  sidekiq_options retry: 3, backtrace: true, unique: :until_and_while_executing
 
   def perform
     gmail_service = GmailService.new

--- a/app/services/schedule_national_holiday_jobs.rb
+++ b/app/services/schedule_national_holiday_jobs.rb
@@ -1,19 +1,19 @@
-class ScheduleNationalHolidayJobs
-  def self.schedule_jobs
-    scheduled_dates = [
-      DateTime.new(2024, 9, 23, 3, 0, 0),
-      DateTime.new(2024, 10, 14, 3, 0, 0),
-      DateTime.new(2024, 11, 4, 3, 0, 0),
-      DateTime.new(2024, 12, 30, 3, 0, 0),
-      DateTime.new(2024, 12, 31, 3, 0, 0)
-    ]
+# class ScheduleNationalHolidayJobs
+#   def self.schedule_jobs
+#     scheduled_dates = [
+#       DateTime.new(2024, 9, 23, 3, 0, 0),
+#       DateTime.new(2024, 10, 14, 3, 0, 0),
+#       DateTime.new(2024, 11, 4, 3, 0, 0),
+#       DateTime.new(2024, 12, 30, 3, 0, 0),
+#       DateTime.new(2024, 12, 31, 3, 0, 0)
+#     ]
 
-    scheduled_dates.each do |date|
-      PostToXJob.set(wait_until: date).perform_later unless job_scheduled?(date)
-    end
-  end
+#     scheduled_dates.each do |date|
+#       PostToXJob.set(wait_until: date).perform_later unless job_scheduled?(date)
+#     end
+#   end
 
-  def self.job_scheduled?(date)
-    Sidekiq::ScheduledSet.new.any? { |job| job.klass == 'PostToXJob' && Time.at(job.at) == date }
-  end
-end
+#   def self.job_scheduled?(date)
+#     Sidekiq::ScheduledSet.new.any? { |job| job.klass == 'PostToXJob' && Time.at(job.at) == date }
+#   end
+# end

--- a/config/initializers/schedule_national_holiday_jobs.rb
+++ b/config/initializers/schedule_national_holiday_jobs.rb
@@ -1,3 +1,3 @@
-Rails.application.config.after_initialize do
-  ScheduleNationalHolidayJobs.schedule_jobs
-end
+# Rails.application.config.after_initialize do
+#   ScheduleNationalHolidayJobs.schedule_jobs
+# end

--- a/spec/services/schedule_national_holiday_jobs_spec.rb
+++ b/spec/services/schedule_national_holiday_jobs_spec.rb
@@ -1,19 +1,19 @@
-require 'rails_helper'
-require 'sidekiq/testing'
+# require 'rails_helper'
+# require 'sidekiq/testing'
 
-RSpec.describe ScheduleNationalHolidayJobs, type: :service do
-  before do
-    Sidekiq::Testing.fake!
-    ActiveJob::Base.queue_adapter = :test
-  end
+# RSpec.describe ScheduleNationalHolidayJobs, type: :service do
+#   before do
+#     Sidekiq::Testing.fake!
+#     ActiveJob::Base.queue_adapter = :test
+#   end
 
-  it 'schedules the jobs only once' do
-    ScheduleNationalHolidayJobs.schedule_jobs
+#   it 'schedules the jobs only once' do
+#     ScheduleNationalHolidayJobs.schedule_jobs
 
-    expect(PostToXJob).to have_been_enqueued.exactly(5).times
+#     expect(PostToXJob).to have_been_enqueued.exactly(5).times
 
-    expect do
-      ScheduleNationalHolidayJobs.schedule_jobs
-    end.not_to(change { Sidekiq::ScheduledSet.new.size })
-  end
-end
+#     expect do
+#       ScheduleNationalHolidayJobs.schedule_jobs
+#     end.not_to(change { Sidekiq::ScheduledSet.new.size })
+#   end
+# end


### PR DESCRIPTION
2024年9月23日（月・祝）12:00、記事が11個投稿される
gem "sidekiq-unique-jobs" 追加しても、RSpecも追加しても、ジョブが重複して実行されることを防げなかった
原因は何だ？Redisにあるのか？コードミスってる？
取り急ぎバグが出ないように、祝日投稿の処理をコメントアウトした